### PR TITLE
[Chore] Bump website to bchd 0.17.0

### DIFF
--- a/src/data.yml
+++ b/src/data.yml
@@ -13,7 +13,7 @@ base_url:         https://bchd.cash
 
 # Info related to latest release downloads
 release:
-  version: v0.16.5
+  version: v0.17.0
   os:
     linux:
       name: Linux


### PR DESCRIPTION
Just updates the site to bchd 0.17.0.